### PR TITLE
Remove dependence on doxygene and openmp for build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,16 +4,22 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra -Wno-noexcept-type -Wno-implicit-fallthrough -Wno-unused-function -march=native -O3 -g")
 
-find_package(OpenMP REQUIRED)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+find_package(OpenMP)
+if (OpenMP_FOUND)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+endif()
 
 include_directories("include")
 
 add_executable(GloveExample "examples/glove.cpp")
-target_link_libraries(GloveExample ${OpenMP_CXX_LIBRARIES})
+if (OpenMP_FOUND)
+    target_link_libraries(GloveExample ${OpenMP_CXX_LIBRARIES})
+endif()
 
 include_directories("test/include")
 add_executable(Test "test/main.cpp" "test/code.cpp")
-target_link_libraries(Test ${OpenMP_CXX_LIBRARIES})
+if (OpenMP_FOUND)
+    target_link_libraries(Test ${OpenMP_CXX_LIBRARIES})
+endif()
 
 add_subdirectory(docs)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,41 +1,43 @@
-find_package(Doxygen REQUIRED)
+find_package(Doxygen)
 
-file(GLOB_RECURSE HEADERS ../include/puffinn/*.hpp)
-set(DOXYGEN_INDEX_FILE ${CMAKE_CURRENT_SOURCE_DIR}/html/index.html)
+if (Doxygen_FOUND)
+    file(GLOB_RECURSE HEADERS ../include/puffinn/*.hpp)
+    set(DOXYGEN_INDEX_FILE ${CMAKE_CURRENT_SOURCE_DIR}/html/index.html)
 
-set(DOXYGEN_INPUT_DIR ${PROJECT_SOURCE_DIR}/include/puffinn)
-set(DOXYGEN_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/doxygen)
-set(DOXYGEN_INDEX_FILE ${DOXYGEN_OUTPUT_DIR}/html/index.html)
-set(DOXYFILE_IN ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in)
-set(DOXYFILE_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
+    set(DOXYGEN_INPUT_DIR ${PROJECT_SOURCE_DIR}/include/puffinn)
+    set(DOXYGEN_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/doxygen)
+    set(DOXYGEN_INDEX_FILE ${DOXYGEN_OUTPUT_DIR}/html/index.html)
+    set(DOXYFILE_IN ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in)
+    set(DOXYFILE_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
 
-configure_file(${DOXYFILE_IN} ${DOXYFILE_OUT} @ONLY)
+    configure_file(${DOXYFILE_IN} ${DOXYFILE_OUT} @ONLY)
 
-file(MAKE_DIRECTORY ${DOXYGEN_OUTPUT_DIR})
-add_custom_command(OUTPUT ${DOXYGEN_INDEX_FILE}
-                   DEPENDS ${HEADERS}
-                   COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYFILE_OUT}
-                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                   MAIN_DEPENDENCY ${DOXYFILE_OUT}
-                   COMMENT "Running Doxygen")
-add_custom_target(Doxygen ALL DEPENDS ${DOXYGEN_INDEX_FILE})
+    file(MAKE_DIRECTORY ${DOXYGEN_OUTPUT_DIR})
+    add_custom_command(OUTPUT ${DOXYGEN_INDEX_FILE}
+                       DEPENDS ${HEADERS}
+                       COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYFILE_OUT}
+                       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                       MAIN_DEPENDENCY ${DOXYFILE_OUT}
+                       COMMENT "Running Doxygen")
+    add_custom_target(Doxygen ALL DEPENDS ${DOXYGEN_INDEX_FILE})
 
-find_package(Sphinx REQUIRED)
+    find_package(Sphinx REQUIRED)
 
-set(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR})
-set(SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/sphinx)
-set(SPHINX_INDEX_FILE ${SPHINX_BUILD}/index.html)
+    set(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR})
+    set(SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/sphinx)
+    set(SPHINX_INDEX_FILE ${SPHINX_BUILD}/index.html)
 
-add_custom_command(OUTPUT ${SPHINX_INDEX_FILE}
-    COMMAND ${SPHINX_EXECUTABLE} -b html -Dbreathe_projects.PUFFINN=${DOXYGEN_OUTPUT_DIR}/xml ${SPHINX_SOURCE} ${SPHINX_BUILD}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS
-    ${CMAKE_CURRENT_SOURCE_DIR}/index.rst
-    ${DOXYGEN_INDEX_FILE} 
-    MAIN_DEPENDENCY ${SPHINX_SOURCE}/conf.py
-    COMMENT "Running Sphinx")
+    add_custom_command(OUTPUT ${SPHINX_INDEX_FILE}
+        COMMAND ${SPHINX_EXECUTABLE} -b html -Dbreathe_projects.PUFFINN=${DOXYGEN_OUTPUT_DIR}/xml ${SPHINX_SOURCE} ${SPHINX_BUILD}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        DEPENDS
+        ${CMAKE_CURRENT_SOURCE_DIR}/index.rst
+        ${DOXYGEN_INDEX_FILE}
+        MAIN_DEPENDENCY ${SPHINX_SOURCE}/conf.py
+        COMMENT "Running Sphinx")
 
-add_custom_target(Sphinx ALL DEPENDS ${SPHINX_INDEX_FILE})
+    add_custom_target(Sphinx ALL DEPENDS ${SPHINX_INDEX_FILE})
 
-include(GNUInstallDirs)
-install(DIRECTORY ${SPHINX_BUILD} DESTINATION ${CMAKE_INSTALL_DOCDIR})
+    include(GNUInstallDirs)
+    install(DIRECTORY ${SPHINX_BUILD} DESTINATION ${CMAKE_INSTALL_DOCDIR})
+endif()

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 import os
 import sys
 
+
 try:
     import pypandoc
     long_description = pypandoc.convert('README.md', 'rst', format='md')
 except (IOError, ImportError):
-    long_description = 'test' #open('README.md').read()
+    long_description = open('README.md').read()
 
 try:
     from setuptools import setup, find_packages, Extension
@@ -13,7 +14,13 @@ except ImportError:
     sys.stderr.write('Setuptools not found!\n')
     raise
 
-extra_args = ['-std=c++14', '-march=native', '-O3', '-fopenmp']
+use_openmp = False
+extra_args = ['-std=c++14', '-march=native', '-O3']
+extra_link_args = []
+
+if use_openmp:
+    extra_args += ['-fopenmp']
+    extra_link_args += ['-fopenmp']
 if sys.platform == 'darwin':
     extra_args += ['-mmacosx-version-min=10.9', '-stdlib=libc++']
     os.environ['LDFLAGS'] = '-mmacosx-version-min=10.9'
@@ -22,7 +29,7 @@ module = Extension(
     'puffinn',
     sources=['python/wrapper/python_wrapper.cpp'],
     extra_compile_args=extra_args,
-    extra_link_args=['-fopenmp'],
+    extra_link_args=extra_link_args,
     include_dirs=['include', 'external/pybind11/include', 'libs'])
 
 setup(
@@ -33,10 +40,10 @@ setup(
     url='https://github.com/',
     description=
     'High-Dimenional Similarity search with guarantees based on Locality-Sensitive Hashing (LSH)',
-    #long_description=long_description,
+    long_description=long_description,
     license='MIT',
     keywords=
-    'nearest neighbor search similarity lsh locality-sensitive hashing cosine distance euclidean',
+    'nearest neighbor search similarity lsh locality-sensitive hashing cosine distance',
     packages=find_packages(),
     include_package_data=True,
     ext_modules=[module])


### PR DESCRIPTION
This removes the mandatory dependency on doxygene and openmp. It seems to work fine without them. This helps on #2 because the default clang on mac os x doesn't support openmp.