### PR TITLE
Only use parallelism during index building.

### DIFF
--- a/include/puffinn/collection.hpp
+++ b/include/puffinn/collection.hpp
@@ -285,7 +285,7 @@ namespace puffinn {
             // Compute hashes for the new vectors in order, so that caching works.
             // Hash a vector in all the different ways needed.
             for (size_t idx=last_rebuild; idx < dataset.get_size(); idx++) {
-                auto hash_state = this->hash_source->reset(dataset[idx]);
+                auto hash_state = this->hash_source->reset(dataset[idx], true);
                 // Only parallelize if this step is computationally expensive.
                 if (hash_source->precomputed_hashes()) {
                     for (auto& map : lsh_maps) {
@@ -421,7 +421,7 @@ namespace puffinn {
 
             MaxBuffer maxbuffer(k);
             g_performance_metrics.start_timer(Computation::Hashing);
-            auto hash_state = hash_source->reset(query);
+            auto hash_state = hash_source->reset(query, false);
             g_performance_metrics.store_time(Computation::Hashing);
             g_performance_metrics.start_timer(Computation::Sketching);
             auto sketches = filterer.reset(query);

--- a/include/puffinn/filterer.hpp
+++ b/include/puffinn/filterer.hpp
@@ -91,7 +91,7 @@ namespace puffinn {
             sketches.reserve(dataset.get_size()*NUM_SKETCHES);
 
             for (size_t idx = first_index; idx < dataset.get_size(); idx++) {
-                auto state = hash_source->reset(dataset[idx]);
+                auto state = hash_source->reset(dataset[idx], true);
                 for (size_t sketch_index = 0; sketch_index < NUM_SKETCHES; sketch_index++) {
                     sketches.push_back((*hash_functions[sketch_index])(state.get()));
                 }
@@ -99,7 +99,7 @@ namespace puffinn {
         }
 
         QuerySketches reset(typename T::Sim::Format::Type* vec) const {
-            auto state = hash_source->reset(vec);
+            auto state = hash_source->reset(vec, false);
 
             QuerySketches res;
             res.query_sketches.reserve(NUM_SKETCHES);

--- a/include/puffinn/hash_source/hash_source.hpp
+++ b/include/puffinn/hash_source/hash_source.hpp
@@ -30,7 +30,8 @@ namespace puffinn {
 
         // Initialize the state necessary to compute the hashes of the given vector.
         virtual std::unique_ptr<HashSourceState> reset(
-            typename T::Sim::Format::Type* vec
+            typename T::Sim::Format::Type* vec,
+            bool parallelize
         ) const = 0;
 
         virtual float collision_probability(

--- a/include/puffinn/hash_source/independent.hpp
+++ b/include/puffinn/hash_source/independent.hpp
@@ -87,7 +87,10 @@ namespace puffinn {
             return (res >> bits_to_cut);
         }
 
-        std::unique_ptr<HashSourceState> reset(typename T::Sim::Format::Type* vec) const {
+        std::unique_ptr<HashSourceState> reset(
+                typename T::Sim::Format::Type* vec,
+                bool parallelize
+        ) const {
             auto state = std::make_unique<IndependentHashSourceState<T>>();
             state->hashed_vec = vec;
             return state;

--- a/include/puffinn/hash_source/pool.hpp
+++ b/include/puffinn/hash_source/pool.hpp
@@ -93,13 +93,23 @@ namespace puffinn {
         }
 
         // Recompute hashes for a new vector.
-        std::unique_ptr<HashSourceState> reset(typename T::Sim::Format::Type* vec) const {
+        std::unique_ptr<HashSourceState> reset(
+                typename T::Sim::Format::Type* vec,
+                bool parallelize
+        ) const {
             auto hashes = std::unique_ptr<LshDatatype>(new LshDatatype[hash_functions.size()]);
                 
-            #pragma omp parallel for
-            for (size_t i=0; i<hash_functions.size(); i++) {
-                hashes.get()[i] = hash_functions[i](vec);
+            if (parallelize) {
+                #pragma omp parallel for
+                for (size_t i=0; i<hash_functions.size(); i++) {
+                    hashes.get()[i] = hash_functions[i](vec);
+                }
+            } else {
+                for (size_t i=0; i<hash_functions.size(); i++) {
+                    hashes.get()[i] = hash_functions[i](vec);
+                }
             }
+
             auto state = std::make_unique<HashPoolState>();
             state->hashes = std::move(hashes);
             return state;

--- a/test/include/hash_source_test.hpp
+++ b/test/include/hash_source_test.hpp
@@ -18,9 +18,9 @@ namespace hash_source {
         auto stored2 = to_stored_type<typename T::Sim::Format>(vec2, dimensions);
 
         auto hasher = source->sample();
-        auto state = source->reset(stored1.get());
+        auto state = source->reset(stored1.get(), false);
         auto hash1 = (*hasher)(state.get());
-        state = source->reset(stored2.get());
+        state = source->reset(stored2.get(), false);
         auto hash2 = (*hasher)(state.get());
         REQUIRE(hash1 != hash2);
     }
@@ -43,7 +43,7 @@ namespace hash_source {
         for (int vec_idx = 0; vec_idx < 2; vec_idx++) {
             auto vec = UnitVectorFormat::generate_random(dimensions.args);
             auto stored = to_stored_type<typename T::Sim::Format>(vec, dimensions);
-            auto state = source->reset(stored.get());
+            auto state = source->reset(stored.get(), false);
             uint64_t max_hash = (((1llu << (hash_length-1))-1) << 1)+1;
 
             for (unsigned int i=0; i < num_hashes; i++) {


### PR DESCRIPTION
I noticed that puffinn's parallelization strategy of the hash value evaluation hurts performance quite badly for iterative queries. (Around 50% starting from 0.5 recall in ann-benchmarks with glove.)

This is an ugly attempt of removing this parallelism during search. It works well, but I hope there is better way of achieving it. 