### PR TITLE
Space usage choice in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ query = ...
 result = index.search(query, 10, 0.8) 
 ```
 
+# Choice of Space Usage
+
+PUFFINN will use as much memory as it is allowed to, which generally gives the best query performance for large datasets (n > 400000). However for smaller datasets using less memory can have better performance.
+During queries, there is a small query overhead per internal hash table used. For smaller datasets, more tables can be used which increases the overhead.
+Another factor to consider is that building the index takes considerable time and is independent of the size of the dataset. This wait might not be worth the small potential speedup of a larger index.
+
+For small datasets, we recommend setting the space usage to at most n^2/60 bytes, where n is the size of the dataset.
+
 # Benchmark
 
 PUFFINN provides fast query times with considerable space usage. It's reliable (see bottom right plot) and doesn't require parameter tuning. 


### PR DESCRIPTION
@maumueller : I added a small section in the readme with a heuristic about space usage.
Before running a query, the query vector is currently hashed for each table. The heuristic is based on making sure that this initialization uses significantly less distance computations than simply doing a brute force search.

For independent simhashes, number of tables L, memory usage M, dataset size N and number of times the initialization distance computations should be smaller than BF search F:
The target number of initialization distance computations is N/F.
The number of init distance computations is 24L.
There are roughly L=M/(8N) tables.
24 M/(8N) = N/F
M = N^2/(3F).
This seems like a reasonable way to get a decent space usage value, but the question is what to set F to. I arbitrarily chose 20 but you probably have a better intuition about what it should be.
