### PR TITLE
add closest_pairs function

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 # PUFFINN - Parameterless and Universal Fast FInding of Nearest Neighbors
 PUFFINN is an easily configurable library for finding the approximate nearest neighbors of arbitrary points.
+It also supports the identification of the closest pairs in the dataset.
 The only necessary parameters are the allowed space usage and the recall.
 Each near neighbor is guaranteed to be found with the probability given by the recall, regardless of the difficulty of the query. 
 
@@ -78,6 +79,10 @@ closest_pairs = index.closest_pairs(k, 0.8)
 
 PUFFINN provides fast query times with considerable space usage. It's reliable (see bottom right plot) and doesn't require parameter tuning. 
 ![Benchmark](https://user-images.githubusercontent.com/6311646/61288829-40903080-a7c8-11e9-9eb0-effc6beb808e.png)
+
+The following benchmark summarizes running times for finding the (globally) $k$-closest pairs in the dataset. 
+
+![Closest Pairs Benchmark](https://github.com/Cecca/puffinn/assets/6311646/b9d96135-0d55-4c01-b00b-60d702312fc3>)
 
 # Authors
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ More details are available in the [documentation](https://puffinn.readthedocs.io
 
 ## C++
 PUFFINN is a header-only library. In most cases, including `puffinn.hpp` is sufficient.
-To use the library, use the `insert`, `rebuild` and `search` methods on `puffinn::Index` as shown in the below example. 
+To use the library, use the `insert`, `rebuild`  and `search` methods on `puffinn::Index` as shown in the below example. 
 Note that points inserted after the last call to `rebuild` cannot be found.
 
 ```cpp
@@ -37,6 +37,10 @@ int main() {
     // Find the approximate 10 nearest neighbors.
     // Each of the true 10 nearest neighbors has at least an 80% chance of being found.
     std::vector<uint32_t> result = index.search(query, 10, 0.8); 
+    
+    // Find the approximate 10 closest pairs in the dataset.
+    // Each of the true 10 closest pairs has at least an 80% chance of being found. 
+    std::vector<std::pair<uint32_t, uint32_t>> result = index.closest_pairs(10, 0.8); 
 }
 ```
 
@@ -64,14 +68,16 @@ query = ...
 # Find the approximate 10 nearest neighbors.
 # Each of the true 10 nearest neighbors has at least an 80% chance of being found.
 result = index.search(query, 10, 0.8) 
+
+# Find the approximate 10 closest pairs in the dataset.
+# Each of the true 10 closest pairs has at least an 80% chance of being found.
+closest_pairs = index.closest_pairs(k, 0.8)
 ```
 
 # Benchmark
 
 PUFFINN provides fast query times with considerable space usage. It's reliable (see bottom right plot) and doesn't require parameter tuning. 
 ![Benchmark](https://user-images.githubusercontent.com/6311646/61288829-40903080-a7c8-11e9-9eb0-effc6beb808e.png)
-
-We plan to integrate PUFFINN into https://github.com/erikbern/ann-benchmarks soon. 
 
 # Authors
 
@@ -80,4 +86,10 @@ PUFFINN is mainly developed by Michael Vesterli. It grew out of a research proje
 > PUFFINN: Parameterless and Universal Fast FInding of Nearest Neighbors, M. Aumüller, T. Christiani, R. Pagh, and M. Vesterli. ESA 2019.
 
 An extended version of the paper is available at https://arxiv.org/abs/1906.12211.
+
+The closest pair functionality was developed by Martin Aumüller and Matteo Ceccarello. Details of the method are available in the following publication
+
+> Solving $k$-Closest Pairs in High-Dimensional Data, M. Aumüller, M. Ceccarello, SISAP 2023. [Link](https://link.springer.com/chapter/10.1007/978-3-031-46994-7_17)
+
+The experimental setup to reproduce the results from the paper is available in the following repository: <https://github.com/Cecca/puffinn>
 

--- a/examples/closest-pairs.py
+++ b/examples/closest-pairs.py
@@ -1,0 +1,68 @@
+import sys
+from puffinn import *
+import numpy
+import time
+import math
+
+import pickle
+def angular_dist(a, b):
+    return numpy.dot(a, b)/(numpy.linalg.norm(a)*numpy.linalg.norm(b))
+
+MB = 1024*1024
+
+dimensions = 100
+n = 1000
+k = 10
+
+# Generate random data and compute the ground truth.
+print('Creating %d %d-dimensional points' % (n, dimensions))
+dataset = [[numpy.random.normal(0, 1) for _ in range(dimensions)]  for _ in range(n)]
+
+print('Computing ground truth')
+ground_truth = [
+    sorted([(angular_dist(q, v), i, j)
+            for (i, v) in enumerate(dataset) if i < j])[-k:] 
+    for (j, q) in enumerate(dataset)
+]
+ground_truth = sorted([tup for topk in ground_truth for tup in topk])[-k:]
+for g in ground_truth:
+    print(g)
+
+# Construct the search index.
+# Here we use angular distance aka cosine similarity
+# with the default hash functions and 500MB memory.
+index = Index('angular', dimensions, 500*MB)
+print('Building index')
+for v in dataset:
+    index.insert(v)
+
+t0 = time.time()
+index.rebuild()
+print("Building index took %.2f seconds." % (time.time() - t0) )
+
+# The index can be stored and loaded using pickle.
+serialized = pickle.dumps(index)
+index = pickle.loads(serialized)
+
+results = []
+print('Searching the index for the closest pairs')
+t0 = time.time()
+results = index.closest_pairs(k, 0.8)
+
+print("Search the index took %.2f seconds." % (time.time() - t0))
+
+found = 0
+dresults = []
+for i, j in results:
+    d = angular_dist(dataset[i], dataset[j])
+    if d >= ground_truth[0][0]:
+        found += 1
+    dresults.append(
+        (d, i, j)
+    )
+dresults = sorted(dresults)
+for d in dresults:
+    print(d)
+
+print("recall: %f" % (found / k))
+

--- a/include/puffinn/maxpairbuffer.hpp
+++ b/include/puffinn/maxpairbuffer.hpp
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "puffinn/typedefs.hpp"
+#include "puffinn/performance.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <utility>
+#include <vector>
+
+namespace puffinn {
+    // Stores the `k` indices with the highest similarities seen so far. Similarities are always values between 0 and 1. 
+    class MaxPairBuffer {
+    public:
+        using ResultPair = std::pair<std::pair<uint32_t, uint32_t>, float>;
+
+    private:
+        const unsigned int size;
+        unsigned int inserted_values;
+        float minval;
+        std::vector<ResultPair> data;
+
+        // Reorder the values, so that the top `k` elements are stored first.
+        // All other values are removed.
+        void filter() {
+            g_performance_metrics.start_timer(Computation::MaxbufferFilter);
+            std::sort(data.begin(), data.begin()+inserted_values,
+                [](const ResultPair& a, const ResultPair& b) {
+                    return a.second > b.second
+                        || (a.second == b.second && a.first > b.first);
+                });
+
+            // Deduplication step
+            unsigned int deduplicated_values = std::min(1u, inserted_values);
+            for (unsigned int idx=1; idx < inserted_values; idx++) {
+                if (data[idx].first != data[deduplicated_values-1].first) {
+                    data[deduplicated_values] = data[idx];
+                    deduplicated_values++;
+                }
+            }
+            inserted_values = std::min(deduplicated_values, size);
+            if (inserted_values == size && size != 0) {
+                minval = data[inserted_values-1].second;
+            }
+            g_performance_metrics.store_time(Computation::MaxbufferFilter);
+        }
+
+    public:
+        // Construct a buffer containing `size` elements. The memory used is twice that.
+        MaxPairBuffer(unsigned int k)
+          : size(k),
+            inserted_values(0),
+            minval(0.0),
+            data(std::vector<ResultPair>(2*k))
+        {
+            if (k == 0) {
+                // Make it impossible to insert.
+                minval = 1.0;
+            }
+        }
+
+        // Insert an index with an associated value into the buffer.
+        // The buffer may choose to ignore it if it is not relevant.
+        bool insert(std::pair<uint32_t, uint32_t> idx, float value) {
+            value = std::min(1.0f, std::max(0.0f, value));
+            // Value is not relevant
+            // This will also discard points with similarity=0, but this will not have an effect on the result.
+            if (value <= minval) { return false; }
+
+            if (inserted_values == 2*size) {
+                filter();
+            }
+            auto elements = idx;
+            if (idx.first > idx.second) {
+                elements = {idx.second, idx.first};
+            }
+            data[inserted_values] = { elements, value };
+            inserted_values++;
+            return true;
+        }
+
+        void add_all(MaxPairBuffer & other) {
+            other.filter();
+            for (size_t i=0; i<other.inserted_values; i++) {
+                insert(other.data[i].first, other.data[i].second);
+            }
+            filter();
+        }
+
+        // Retrieve the `k` entries with the highest associated values.
+        std::vector<ResultPair> best_entries() {
+            filter();
+            std::vector<ResultPair> res;
+            for (unsigned i=0; i<inserted_values; i++) {
+                res.push_back(data[i]);
+            }
+            return res;
+        }
+
+        std::vector<std::pair<uint32_t, uint32_t>> best_indices() {
+            auto entries = best_entries();
+            std::vector<std::pair<uint32_t, uint32_t>> res;
+            res.reserve(entries.size());
+            for (auto entry : entries) {
+                res.push_back(entry.first);
+            }
+            return res;
+        }
+
+        // Retrieve the current smallest values that inserted values have to beat
+        // in order to be considered.
+        float smallest_value() const {
+            return minval;
+        }
+
+        // Retrieve the i'th inserted index when sorted by their descending values.
+        //
+        // buffer[0] will be the index with the largest associated value,
+        // buffer[k-1] will be the index with the least associated value.
+        // This does not take into account values that are inserted after the last filter.
+        std::pair<uint32_t, uint32_t> operator[](size_t i) const {
+            return data[i].first;
+        }
+    };
+}

--- a/include/puffinn/prefixmap.hpp
+++ b/include/puffinn/prefixmap.hpp
@@ -68,9 +68,11 @@ namespace puffinn {
         // Number of bits to precompute locations in the stored vector for.
         const static int PREFIX_INDEX_BITS = 13;
 
+      public:
         // contents
         std::vector<uint32_t> indices;
         std::vector<LshDatatype> hashes;
+      private:
         // Scratch space for use when rebuilding. The length and capacity is set to 0 otherwise.
         std::vector<HashedVecIdx> rebuilding_data;
 
@@ -276,6 +278,10 @@ namespace puffinn {
                 query.prefix_mask <<= 1;
                 return std::make_pair(&indices[start_idx], &indices[end_idx]);
             }
+        }
+
+        std::pair<const uint32_t*, const uint32_t*> get_segment(size_t left, size_t right) {
+            return std::make_pair(&indices[left], &indices[right]);
         }
 
         static uint64_t memory_usage(size_t size, uint64_t function_size) {

--- a/python/wrapper/python_wrapper.cpp
+++ b/python/wrapper/python_wrapper.cpp
@@ -38,6 +38,11 @@ struct AbstractIndex {
         float recall,
         FilterType filter_type
     ) = 0;
+    virtual std::vector<std::pair<uint32_t, uint32_t>> closest_pairs(
+        unsigned int k,
+        float recall,
+        FilterType filter_type
+    ) = 0;
     virtual void serialize(std::ostream& out) = 0;
     virtual std::string metric() = 0;
     virtual std::string hash_function() = 0;
@@ -92,6 +97,14 @@ public:
         FilterType filter_type
     ) {
         return table.search(vec, k, recall, filter_type);
+    }
+
+    std::vector<std::pair<uint32_t, uint32_t>> closest_pairs(
+        unsigned int k,
+        float recall,
+        FilterType filter_type
+    ) {
+        return table.closest_pairs(k, recall, filter_type);
     }
 
     std::vector<uint32_t> search_from_index(
@@ -181,6 +194,14 @@ public:
         FilterType filter_type
     ) {
         return table.search(vec, k, recall, filter_type);
+    }
+
+    std::vector<std::pair<uint32_t, uint32_t>> closest_pairs(
+        unsigned int k,
+        float recall,
+        FilterType filter_type
+    ) {
+        return table.closest_pairs(k, recall, filter_type);
     }
 
     std::vector<uint32_t> search_from_index(
@@ -319,6 +340,19 @@ public:
         } else {
             auto vec = list.cast<std::vector<unsigned int>>();
             return set_table->search(vec, k, recall, filter_type);
+        }
+    }
+
+    std::vector<std::pair<uint32_t, uint32_t>> closest_pairs(
+        unsigned int k,
+        float recall,
+        std::string filter_name
+    ) {
+        auto filter_type = get_filter_type(filter_name);
+        if (real_table) {
+            return real_table->closest_pairs(k, recall, filter_type);
+        } else {
+            return set_table->closest_pairs(k, recall, filter_type);
         }
     }
 
@@ -526,6 +560,10 @@ PYBIND11_MODULE(puffinn, m) {
          )
         .def("search_from_index", &Index::search_from_index,
             py::arg("index"), py::arg("k"), py::arg("recall"),
+            py::arg("filter_type") = "default"
+        )
+        .def("closest_pairs", &Index::closest_pairs,
+            py::arg("k"), py::arg("recall"),
             py::arg("filter_type") = "default"
         )
         .def("get", &Index::get)

--- a/setup.py
+++ b/setup.py
@@ -14,17 +14,16 @@ except ImportError:
     sys.stderr.write('Setuptools not found!\n')
     raise
 
-# native clang doesn't support openmp
-# TODO add better way to check for openmp
-use_openmp = sys.platform != 'darwin'
+
 extra_args = ['-std=c++14', '-march=native', '-O3']
 extra_link_args = []
 
-if use_openmp:
+if sys.platform != 'darwin':
     extra_args += ['-fopenmp']
     extra_link_args += ['-fopenmp']
-if sys.platform == 'darwin':
-    extra_args += ['-mmacosx-version-min=10.9', '-stdlib=libc++']
+else:
+    extra_args += ['-mmacosx-version-min=10.9', '-stdlib=libc++', '-Xclang', '-fopenmp']
+    extra_link_args += ['-lomp']
     os.environ['LDFLAGS'] = '-mmacosx-version-min=10.9'
 
 module = Extension(
@@ -36,8 +35,8 @@ module = Extension(
 
 setup(
     name='PUFFINN',
-    version='0.1',
-    author='Michael Erik Vesterli, Martin Aumüller',
+    version='0.2',
+    author='Michael Erik Vesterli, Martin Aumüller, Matteo Ceccarello',
     author_email='maau@itu.dk',
     url='https://github.com/',
     description=
@@ -45,7 +44,7 @@ setup(
     long_description=long_description,
     license='MIT',
     keywords=
-    'nearest neighbor search similarity lsh locality-sensitive hashing cosine distance',
+    'nearest neighbor search similarity lsh locality-sensitive hashing cosine distance closest pair',
     packages=find_packages(),
     include_package_data=True,
     ext_modules=[module])


### PR DESCRIPTION
This commit backports to the upstream code the functionality implemented in the SISAP2023 paper _Solving k-Closest Pairs in High-Dimensional Data using Locality-Sensitive Hashing_

It also provides a function `closest_pairs` on the `Index` Python object