### PR TITLE
Backport changes to the hashing infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ cmake_install.cmake
 PUFFINN.egg-info
 build
 dist
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ cmake_install.cmake
 *.log
 PUFFINN.egg-info
 build
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ cmake_install.cmake
 *.pdf
 *.aux
 *.log
+PUFFINN.egg-info
+build

--- a/include/puffinn/collection.hpp
+++ b/include/puffinn/collection.hpp
@@ -286,7 +286,7 @@ namespace puffinn {
 
             // Compute hashes for the new vectors in order, so that caching works.
             // Hash a vector in all the different ways needed.
-            std::vector<std::vector<LshDatatype>> tl_hash_values;
+            std::vector<std::vector<uint64_t>> tl_hash_values;
             tl_hash_values.resize(omp_get_max_threads());
             for (size_t i=0; i < tl_hash_values.size(); i++) {
                 tl_hash_values[i].resize(lsh_maps.size());
@@ -561,7 +561,7 @@ namespace puffinn {
             MaxBuffer maxbuffer(k);
             g_performance_metrics.start_timer(Computation::Hashing);
             // FIXME: re-use this allocation!
-            std::vector<LshDatatype> query_hashes;
+            std::vector<uint64_t> query_hashes;
             hash_source->hash_repetitions(query, query_hashes);
             g_performance_metrics.store_time(Computation::Hashing);
 
@@ -625,7 +625,7 @@ namespace puffinn {
             SearchBuffers(
                 const std::vector<PrefixMap<THash>>& maps,
                 QuerySketches sketches,
-                std::vector<LshDatatype> & hashes
+                std::vector<uint64_t> & hashes
             )
               : sketches(sketches)
             {
@@ -670,7 +670,7 @@ namespace puffinn {
             MaxBuffer& maxbuffer,
             float recall,
             QuerySketches sketches,
-            std::vector<LshDatatype> & query_hashes
+            std::vector<uint64_t> & query_hashes
         ) const {
             SearchBuffers buffers(lsh_maps, sketches, query_hashes);
             for (uint_fast8_t depth=MAX_HASHBITS; depth > 0; depth--) {
@@ -716,7 +716,7 @@ namespace puffinn {
             float recall,
             QuerySketches sketches,
             // TODO make const
-            std::vector<LshDatatype> & query_hashes
+            std::vector<uint64_t> & query_hashes
         ) const {
             SearchBuffers buffers(lsh_maps, sketches, query_hashes);
             for (uint_fast8_t depth=MAX_HASHBITS; depth > 0; depth--) {
@@ -768,7 +768,7 @@ namespace puffinn {
             float recall,
             QuerySketches sketches,
             // TODO Make const
-            std::vector<LshDatatype> & query_hashes
+            std::vector<uint64_t> & query_hashes
         ) const {
             const size_t FILTER_BUFFER_SIZE = 128;
 

--- a/include/puffinn/filterer.hpp
+++ b/include/puffinn/filterer.hpp
@@ -88,12 +88,14 @@ namespace puffinn {
             const Dataset<typename T::Sim::Format>& dataset,
             uint32_t first_index
         ) {
-            sketches.reserve(dataset.get_size()*NUM_SKETCHES);
+            sketches.resize(dataset.get_size()*NUM_SKETCHES);
 
+            #pragma omp parallel for schedule(dynamic)
             for (size_t idx = first_index; idx < dataset.get_size(); idx++) {
                 auto state = hash_source->reset(dataset[idx], true);
+                size_t offset = idx * NUM_SKETCHES;
                 for (size_t sketch_index = 0; sketch_index < NUM_SKETCHES; sketch_index++) {
-                    sketches.push_back((*hash_functions[sketch_index])(state.get()));
+                    sketches[offset + sketch_index] = (*hash_functions[sketch_index])(state.get());
                 }
             }
         }

--- a/include/puffinn/filterer.hpp
+++ b/include/puffinn/filterer.hpp
@@ -108,22 +108,9 @@ namespace puffinn {
             }
         }
 
-        void sketch(typename T::Sim::Format::Type* vec, QuerySketches & output) const {
+        void sketch(const typename T::Sim::Format::Type* const vec, QuerySketches & output) const {
             hash_source->hash_repetitions(vec, output.query_sketches);
             output.max_sketch_diff = NUM_FILTER_HASHBITS;
-        }
-
-        QuerySketches reset(typename T::Sim::Format::Type* vec) const {
-            /* throw "stop!"; */
-            auto state = hash_source->reset(vec, false);
-
-            QuerySketches res;
-            res.query_sketches.reserve(NUM_SKETCHES);
-            for (size_t sketch_index=0; sketch_index<NUM_SKETCHES; sketch_index++) {
-                res.query_sketches.push_back((*hash_functions[sketch_index])(state.get()));
-            }
-            res.max_sketch_diff = NUM_FILTER_HASHBITS;
-            return res;
         }
 
         void prefetch(uint32_t idx, int_fast32_t sketch_idx) const {

--- a/include/puffinn/filterer.hpp
+++ b/include/puffinn/filterer.hpp
@@ -108,7 +108,13 @@ namespace puffinn {
             }
         }
 
+        void sketch(typename T::Sim::Format::Type* vec, QuerySketches & output) const {
+            hash_source->hash_repetitions(vec, output.query_sketches);
+            output.max_sketch_diff = NUM_FILTER_HASHBITS;
+        }
+
         QuerySketches reset(typename T::Sim::Format::Type* vec) const {
+            /* throw "stop!"; */
             auto state = hash_source->reset(vec, false);
 
             QuerySketches res;

--- a/include/puffinn/hash/crosspolytope.hpp
+++ b/include/puffinn/hash/crosspolytope.hpp
@@ -184,7 +184,7 @@ namespace puffinn {
         }
 
         // Hash the given vector
-        LshDatatype operator()(int16_t* vec) const {
+        LshDatatype operator()(const int16_t* const vec) const {
             float rotated_vec[1 << log_dimensions];
 
             // Reset rotation vec
@@ -353,7 +353,7 @@ namespace puffinn {
             out.write(reinterpret_cast<const char*>(random_matrix.get()), matrix_len*sizeof(int16_t));
         }
 
-        LshDatatype operator()(int16_t* vec) const {
+        LshDatatype operator()(const int16_t* const vec) const {
             LshDatatype res = 0;
             uint16_t max_abs_dot = 0;
             for (unsigned int i=0; i<(1u << ceil_log(dimensions)); i++) {

--- a/include/puffinn/hash/minhash.hpp
+++ b/include/puffinn/hash/minhash.hpp
@@ -113,7 +113,7 @@ namespace puffinn {
             permutation.serialize(out);
         }
 
-        LshDatatype operator()(std::vector<uint32_t>* vec) const {
+        LshDatatype operator()(const std::vector<uint32_t>* const vec) const {
             uint64_t min_hash = 0xFFFFFFFFFFFFFFFF; // 2^64-1
             uint32_t min_token = 0;
             for (uint32_t i : *vec) {
@@ -238,7 +238,7 @@ namespace puffinn {
             hash.serialize(out);
         }
 
-        LshDatatype operator()(std::vector<uint32_t>* vec) const {
+        LshDatatype operator()(const std::vector<uint32_t>* const vec) const {
             return hash(vec)%2;
         }
     };

--- a/include/puffinn/hash/simhash.hpp
+++ b/include/puffinn/hash/simhash.hpp
@@ -38,7 +38,7 @@ namespace puffinn {
         }
 
         // Hash the given vector.
-        LshDatatype operator()(int16_t* vec) const {
+        LshDatatype operator()(const int16_t * const vec) const {
             auto dot = dot_product_i16(hash_vec.get(), vec, dimensions);
             return dot >= UnitVectorFormat::to_16bit_fixed_point(0.0);
         }

--- a/include/puffinn/hash_source/hash_source.hpp
+++ b/include/puffinn/hash_source/hash_source.hpp
@@ -25,9 +25,6 @@ namespace puffinn {
     public:
         virtual ~HashSource() {}
 
-        // Sample a random hash function from this source.
-        virtual std::unique_ptr<Hash> sample() = 0;
-
         // Compute the LSH values for all tables supported by this pool for the given input vector.
         // Writes the results to the given output array, which can be reused
         virtual void hash_repetitions(

--- a/include/puffinn/hash_source/hash_source.hpp
+++ b/include/puffinn/hash_source/hash_source.hpp
@@ -35,12 +35,6 @@ namespace puffinn {
             std::vector<uint64_t> & output
         ) const = 0;
 
-        // Initialize the state necessary to compute the hashes of the given vector.
-        virtual std::unique_ptr<HashSourceState> reset(
-            typename T::Sim::Format::Type* vec,
-            bool parallelize
-        ) const = 0;
-
         virtual float collision_probability(
             float similarity,
             uint_fast8_t num_bits

--- a/include/puffinn/hash_source/hash_source.hpp
+++ b/include/puffinn/hash_source/hash_source.hpp
@@ -28,6 +28,13 @@ namespace puffinn {
         // Sample a random hash function from this source.
         virtual std::unique_ptr<Hash> sample() = 0;
 
+        // Compute the LSH values for all tables supported by this pool for the given input vector.
+        // Writes the results to the given output array, which can be reused
+        virtual void hash_repetitions(
+            typename T::Sim::Format::Type * input,
+            std::vector<LshDatatype> & output
+        ) const = 0;
+
         // Initialize the state necessary to compute the hashes of the given vector.
         virtual std::unique_ptr<HashSourceState> reset(
             typename T::Sim::Format::Type* vec,

--- a/include/puffinn/hash_source/hash_source.hpp
+++ b/include/puffinn/hash_source/hash_source.hpp
@@ -31,7 +31,7 @@ namespace puffinn {
         // Compute the LSH values for all tables supported by this pool for the given input vector.
         // Writes the results to the given output array, which can be reused
         virtual void hash_repetitions(
-            typename T::Sim::Format::Type * input,
+            const typename T::Sim::Format::Type * const input,
             std::vector<LshDatatype> & output
         ) const = 0;
 

--- a/include/puffinn/hash_source/hash_source.hpp
+++ b/include/puffinn/hash_source/hash_source.hpp
@@ -3,10 +3,6 @@
 #include <ostream>
 
 namespace puffinn {
-    class Hash;
-
-    class HashSourceState {};
-
     enum class HashSourceType {
         Independent,
         Pool,
@@ -60,24 +56,8 @@ namespace puffinn {
             return std::pow(whole_hashes_prob, whole_hashes)*remaining_prob;
         }
 
-        // Whether hashes are computed when calling reset.
-        virtual bool precomputed_hashes() const = 0;
-
         virtual void serialize(std::ostream&) const = 0;
 
-        virtual std::unique_ptr<Hash> deserialize_hash(std::istream& in) const = 0;
-    };
-
-    // A hash function sampled from a HashSource.
-    class Hash {
-    public:
-        virtual ~Hash() {}
-        // Compute the hash of the vector that the source was last reset with.
-        //
-        // It can be assumed that the state is created by the same source as the hash.
-        virtual uint64_t operator()(HashSourceState*) const = 0;
-
-        virtual void serialize(std::ostream&) const = 0;
     };
 
     /// Arguments that can be supplied with data from the ``LSHTable`` to construct a HashSource.

--- a/include/puffinn/hash_source/hash_source.hpp
+++ b/include/puffinn/hash_source/hash_source.hpp
@@ -32,7 +32,7 @@ namespace puffinn {
         // Writes the results to the given output array, which can be reused
         virtual void hash_repetitions(
             const typename T::Sim::Format::Type * const input,
-            std::vector<LshDatatype> & output
+            std::vector<uint64_t> & output
         ) const = 0;
 
         // Initialize the state necessary to compute the hashes of the given vector.

--- a/include/puffinn/hash_source/independent.hpp
+++ b/include/puffinn/hash_source/independent.hpp
@@ -110,12 +110,6 @@ namespace puffinn {
             return hash_functions.size()/functions_per_hasher;
         }
 
-        std::unique_ptr<Hash> sample() {
-            auto res = std::make_unique<IndependentHasher<T>>(this, next_function);
-            next_function += functions_per_hasher;
-            return res;
-        }
-
         uint_fast8_t get_bits_per_function() const {
             return bits_per_function;
         }

--- a/include/puffinn/hash_source/independent.hpp
+++ b/include/puffinn/hash_source/independent.hpp
@@ -77,13 +77,13 @@ namespace puffinn {
 
         void hash_repetitions(
             const typename T::Sim::Format::Type * const input,
-            std::vector<LshDatatype> & output
+            std::vector<uint64_t> & output
         ) const {
             output.resize(num_hashers);
             // Iterate through all the functions, accumulating bits
             for (size_t rep = 0; rep < num_hashers; rep++) {
                 size_t offset = rep * functions_per_hasher;
-                LshDatatype res = 0;
+                uint64_t res = 0;
                 for (unsigned int i=0; i < functions_per_hasher; i++) {
                     res <<= bits_per_function;
                     res |= hash_functions[offset+i](input);

--- a/include/puffinn/hash_source/independent.hpp
+++ b/include/puffinn/hash_source/independent.hpp
@@ -105,15 +105,6 @@ namespace puffinn {
             return res >> bits_to_cut;
         }
 
-        std::unique_ptr<HashSourceState> reset(
-                typename T::Sim::Format::Type* vec,
-                bool /*parallelize*/
-        ) const {
-            auto state = std::make_unique<IndependentHashSourceState<T>>();
-            state->hashed_vec = vec;
-            return state;
-        }
-
         // Retrieve the number of functions this source can create.
         size_t get_size() const {
             return hash_functions.size()/functions_per_hasher;

--- a/include/puffinn/hash_source/independent.hpp
+++ b/include/puffinn/hash_source/independent.hpp
@@ -76,9 +76,7 @@ namespace puffinn {
         }
 
         void hash_repetitions(
-            // TODO: Make this argument const. Currently it does not compile if we make it 
-            // const because the hash function accepts a mutable pointer
-            typename T::Sim::Format::Type * input,
+            const typename T::Sim::Format::Type * const input,
             std::vector<LshDatatype> & output
         ) const {
             output.resize(num_hashers);

--- a/include/puffinn/hash_source/pool.hpp
+++ b/include/puffinn/hash_source/pool.hpp
@@ -144,12 +144,12 @@ namespace puffinn {
 
         void hash_repetitions(
             const typename T::Sim::Format::Type * const input,
-            std::vector<LshDatatype> & output
+            std::vector<uint64_t> & output
         ) const {
             output.clear();
 
             // TODO: remove this allocation and reuse the scratch space
-            std::vector<LshDatatype> pool;
+            std::vector<uint64_t> pool;
             pool.reserve(hash_functions.size());
 
             for (size_t i = 0; i < hash_functions.size(); i++) {

--- a/include/puffinn/hash_source/pool.hpp
+++ b/include/puffinn/hash_source/pool.hpp
@@ -143,9 +143,7 @@ namespace puffinn {
         }
 
         void hash_repetitions(
-            // TODO: Make this argument const. Currently it does not compile if we make it 
-            // const because the hash function accepts a mutable pointer
-            typename T::Sim::Format::Type * input,
+            const typename T::Sim::Format::Type * const input,
             std::vector<LshDatatype> & output
         ) const {
             output.clear();

--- a/include/puffinn/hash_source/pool.hpp
+++ b/include/puffinn/hash_source/pool.hpp
@@ -158,36 +158,13 @@ namespace puffinn {
 
             for (size_t rep = 0; rep < num_tables; rep++) {
                 // Concatenate the hashes
-                uint32_t res = 0;
+                uint64_t res = 0;
                 for (auto idx : indices[rep]) {
                     res <<= bits_per_function;
                     res |= pool[idx];
                 }
                 output.push_back(res >> bits_to_cut);
             }
-        }
-
-        // Recompute hashes for a new vector.
-        std::unique_ptr<HashSourceState> reset(
-                typename T::Sim::Format::Type* vec,
-                bool parallelize
-        ) const {
-            auto hashes = std::unique_ptr<LshDatatype>(new LshDatatype[hash_functions.size()]);
-                
-            if (parallelize) {
-                #pragma omp parallel for
-                for (size_t i=0; i<hash_functions.size(); i++) {
-                    hashes.get()[i] = hash_functions[i](vec);
-                }
-            } else {
-                for (size_t i=0; i<hash_functions.size(); i++) {
-                    hashes.get()[i] = hash_functions[i](vec);
-                }
-            }
-
-            auto state = std::make_unique<HashPoolState>();
-            state->hashes = std::move(hashes);
-            return state;
         }
 
         float icollision_probability(float p) const {

--- a/include/puffinn/hash_source/pool.hpp
+++ b/include/puffinn/hash_source/pool.hpp
@@ -114,10 +114,6 @@ namespace puffinn {
             out.write(reinterpret_cast<const char*>(&bits_to_cut), sizeof(unsigned int));
         }
 
-        std::unique_ptr<Hash> sample() {
-            return std::make_unique<PooledHasher<T>>(this, indices[current_sampling_rep++]);
-        }
-
         uint64_t concatenate_hash(
             const std::vector<unsigned int>& indices,
             const LshDatatype* hashes

--- a/include/puffinn/hash_source/pool.hpp
+++ b/include/puffinn/hash_source/pool.hpp
@@ -3,10 +3,6 @@
 #include "puffinn/dataset.hpp"
 #include "puffinn/hash_source/hash_source.hpp"
 
-#include <memory>
-#include <limits>
-#include <random>
-
 namespace puffinn {
     template<typename T>
     class PooledHasher;
@@ -23,17 +19,23 @@ namespace puffinn {
     class HashPool : public HashSource<T> {
         T hash_family;
         std::vector<typename T::Function> hash_functions;
+        std::vector<std::vector<unsigned int>> indices;
+        unsigned int num_tables;
         uint_fast8_t bits_per_function;
         unsigned int bits_per_hasher;
+        unsigned int current_sampling_rep = 0;
+        unsigned int bits_to_cut;
 
     public:
         HashPool(
             DatasetDescription<typename T::Sim::Format> desc,
             typename T::Args args,
             unsigned int num_functions,
+            unsigned int num_tables,
             unsigned int bits_per_hasher
         )
           : hash_family(desc, args),
+            num_tables(num_tables),
             bits_per_function(hash_family.bits_per_function()),
             bits_per_hasher(bits_per_hasher)
         {
@@ -42,6 +44,21 @@ namespace puffinn {
             for (unsigned int i=0; i < num_functions; i++) {
                 hash_functions.push_back(hash_family.sample());
             }
+
+            auto& rand_gen = get_default_random_generator();
+            std::uniform_int_distribution<unsigned int> random_idx(0, num_functions-1);
+            
+            indices.reserve(num_tables);
+            for (size_t rep = 0; rep < num_tables; rep++) {
+                std::vector<unsigned int> rep_indices;
+                rep_indices.reserve(bits_per_hasher);
+                for (size_t i=0; i < bits_per_hasher; i += bits_per_function) {
+                    rep_indices.push_back(random_idx(rand_gen));
+                }
+                indices.push_back(rep_indices);
+            }
+
+            bits_to_cut = bits_per_function * indices[0].size() - bits_per_hasher;
         }
 
         HashPool(std::istream& in)
@@ -53,8 +70,25 @@ namespace puffinn {
             for (size_t i=0; i < len; i++) {
                 hash_functions.emplace_back(in);
             }
+            size_t len_indices;
+            in.read(reinterpret_cast<char*>(&len_indices), sizeof(size_t));
+            for (size_t i=0; i < len_indices; i++) {
+                std::vector<unsigned int> rep_indices;
+                size_t len_index_array;
+                in.read(reinterpret_cast<char*>(&len_index_array), sizeof(size_t));
+                for (size_t j=0; j < len_index_array; j++) {
+                    unsigned int idx;
+                    in.read(reinterpret_cast<char*>(&idx), sizeof(unsigned int));
+                    rep_indices.push_back(idx);
+                }
+                indices.push_back(rep_indices);
+            }
+
+            in.read(reinterpret_cast<char*>(&num_tables), sizeof(unsigned int));
             in.read(reinterpret_cast<char*>(&bits_per_function), sizeof(uint_fast8_t));
             in.read(reinterpret_cast<char*>(&bits_per_hasher), sizeof(unsigned int));
+            in.read(reinterpret_cast<char*>(&current_sampling_rep), sizeof(unsigned int));
+            in.read(reinterpret_cast<char*>(&bits_to_cut), sizeof(unsigned int));
         }
 
         void serialize(std::ostream& out) const {
@@ -64,12 +98,24 @@ namespace puffinn {
             for (auto& h : hash_functions) {
                 h.serialize(out);
             }
+            size_t len_indices = indices.size();
+            out.write(reinterpret_cast<char*>(&len_indices), sizeof(size_t));
+            for (auto& index_vec : indices) {
+                size_t len_index_vec = index_vec.size();
+                out.write(reinterpret_cast<char*>(&len_index_vec), sizeof(size_t));
+                for (auto i : index_vec) {
+                    out.write(reinterpret_cast<const char*>(&i), sizeof(unsigned int));
+                }
+            }
+            out.write(reinterpret_cast<const char*>(&num_tables), sizeof(unsigned int));
             out.write(reinterpret_cast<const char*>(&bits_per_function), sizeof(uint_fast8_t));
             out.write(reinterpret_cast<const char*>(&bits_per_hasher), sizeof(unsigned int));
+            out.write(reinterpret_cast<const char*>(&current_sampling_rep), sizeof(unsigned int));
+            out.write(reinterpret_cast<const char*>(&bits_to_cut), sizeof(unsigned int));
         }
 
         std::unique_ptr<Hash> sample() {
-            return std::make_unique<PooledHasher<T>>(this, bits_per_hasher);
+            return std::make_unique<PooledHasher<T>>(this, indices[current_sampling_rep++]);
         }
 
         uint64_t concatenate_hash(
@@ -90,6 +136,37 @@ namespace puffinn {
 
         uint_fast8_t get_bits_per_function() const {
             return bits_per_function;
+        }
+
+        uint_fast8_t get_bits_per_hasher() const {
+            return bits_per_hasher;
+        }
+
+        void hash_repetitions(
+            // TODO: Make this argument const. Currently it does not compile if we make it 
+            // const because the hash function accepts a mutable pointer
+            typename T::Sim::Format::Type * input,
+            std::vector<LshDatatype> & output
+        ) const {
+            output.clear();
+
+            // TODO: remove this allocation and reuse the scratch space
+            std::vector<LshDatatype> pool;
+            pool.reserve(hash_functions.size());
+
+            for (size_t i = 0; i < hash_functions.size(); i++) {
+                pool.push_back(hash_functions[i](input));
+            }
+
+            for (size_t rep = 0; rep < num_tables; rep++) {
+                // Concatenate the hashes
+                uint32_t res = 0;
+                for (auto idx : indices[rep]) {
+                    res <<= bits_per_function;
+                    res |= pool[idx];
+                }
+                output.push_back(res >> bits_to_cut);
+            }
         }
 
         // Recompute hashes for a new vector.
@@ -113,6 +190,10 @@ namespace puffinn {
             auto state = std::make_unique<HashPoolState>();
             state->hashes = std::move(hashes);
             return state;
+        }
+
+        float icollision_probability(float p) const {
+            return hash_family.icollision_probability(p);
         }
 
         float collision_probability(
@@ -157,17 +238,10 @@ namespace puffinn {
     public:
         // Create a hash function reusing the given pool.
         // The resulting hash consists of exactly the given number of bits.
-        PooledHasher(const HashPool<T> *pool, size_t hash_length)
-          : pool(pool)
+        PooledHasher(const HashPool<T> *pool, std::vector<unsigned int> & indices)
+          : pool(pool), indices(indices)
         {
-            auto& rand_gen = get_default_random_generator();
-            int bits_per_function = pool->get_bits_per_function();
-            std::uniform_int_distribution<unsigned int> random_idx(0, pool->get_size()-1);
-            for (size_t i=0; i < hash_length; i += bits_per_function) {
-                indices.push_back(random_idx(rand_gen));
-            }
-            indices.shrink_to_fit();
-            bits_to_cut = pool->get_bits_per_function()*indices.size()-hash_length;
+            bits_to_cut = pool->get_bits_per_function()*indices.size()-pool->get_bits_per_hasher();
         }
 
         PooledHasher(std::istream& in, const HashPool<T>* pool)
@@ -232,13 +306,14 @@ namespace puffinn {
 
         std::unique_ptr<HashSource<T>> build(
             DatasetDescription<typename T::Sim::Format> desc,
-            unsigned int /* num_tables */,
+            unsigned int num_tables,
             unsigned int num_bits_per_function
         ) const {
             return std::make_unique<HashPool<T>> (
                 desc,
                 args,
                 pool_size,
+                num_tables,
                 num_bits_per_function
             );
         }

--- a/include/puffinn/hash_source/tensor.hpp
+++ b/include/puffinn/hash_source/tensor.hpp
@@ -46,6 +46,7 @@ namespace puffinn {
     class TensoredHashSource : public HashSource<T> {
         IndependentHashSource<T> independent_hash_source;
         std::vector<std::unique_ptr<Hash>> hashers;
+        unsigned int num_hashers;
         unsigned int next_hash_idx = 0;
         unsigned int num_bits;
 
@@ -63,6 +64,7 @@ namespace puffinn {
                 args,
                 2*std::ceil(std::sqrt(static_cast<float>(num_hashers))),
                 (num_bits+1)/2),
+            num_hashers(num_hashers),
             num_bits(num_bits)
         {
             for (unsigned int i=0; i < independent_hash_source.get_size(); i++) {
@@ -81,6 +83,7 @@ namespace puffinn {
                 // it does not matter that it is not the 'correct' arguments.
                 hashers.push_back(independent_hash_source.deserialize_hash(in));
             }
+            in.read(reinterpret_cast<char*>(&num_hashers), sizeof(unsigned int));
             in.read(reinterpret_cast<char*>(&next_hash_idx), sizeof(unsigned int));
             in.read(reinterpret_cast<char*>(&num_bits), sizeof(unsigned int));
         }
@@ -92,6 +95,7 @@ namespace puffinn {
             for (auto& h : hashers) {
                 h->serialize(out);
             }
+            out.write(reinterpret_cast<const char*>(&num_hashers), sizeof(unsigned int));
             out.write(reinterpret_cast<const char*>(&next_hash_idx), sizeof(unsigned int));
             out.write(reinterpret_cast<const char*>(&num_bits), sizeof(unsigned int));
         }
@@ -103,6 +107,49 @@ namespace puffinn {
                 this,
                 index_pair.first,
                 index_pair.second);
+        }
+
+        void hash_repetitions(
+            // TODO: Make this argument const. Currently it does not compile if we make it 
+            // const because the hash function accepts a mutable pointer
+            typename T::Sim::Format::Type * input,
+            std::vector<LshDatatype> & output
+        ) const {
+            // In order to avoid allocating a new vector to hold the tensored data
+            // every time we hash something, we make the output vector a little bit larger:
+            // enough to store both the output **and** the tensored repetitions.
+            // After computing the tensored repetitions directly in the output
+            // vector, we move them to the end, and place the actual output hashes
+            // in the first part of `output`. Finally, we trim the size so that
+            // the caller does not see the scratch work. Note that calling `resize`
+            // does not de-allocate the memory, so on the next call we will not make
+            // an allocation again.
+            size_t tensored_hashers = independent_hash_source.get_size();
+            independent_hash_source.hash_repetitions(input, output);
+            output.resize(num_hashers + tensored_hashers);
+            for (size_t i=0; i<tensored_hashers; i++) {
+                output[num_hashers+i] = intersperse_zero(output[i]);
+            }
+            size_t right_start = tensored_hashers / 2;
+
+            if (num_bits % 2 == 0) {
+                for (size_t i=0; i < tensored_hashers / 2; i++) {
+                    output[num_hashers + i] <<= 1;
+                }
+            } else {
+                for (size_t i=right_start; i < tensored_hashers; i++) {
+                    output[num_hashers + i] >>= 1;
+                }
+            }
+
+            for(size_t rep=0; rep < num_hashers; rep++) {
+                auto index_pair = get_minimal_index_pair(rep);
+                uint32_t h_left = output[num_hashers + index_pair.first];
+                uint32_t h_right = output[num_hashers + right_start + index_pair.second];
+                uint32_t h = h_left | h_right;
+                output[rep] = h;
+            }
+            output.resize(num_hashers);
         }
 
         std::unique_ptr<HashSourceState> reset(

--- a/include/puffinn/hash_source/tensor.hpp
+++ b/include/puffinn/hash_source/tensor.hpp
@@ -110,9 +110,7 @@ namespace puffinn {
         }
 
         void hash_repetitions(
-            // TODO: Make this argument const. Currently it does not compile if we make it 
-            // const because the hash function accepts a mutable pointer
-            typename T::Sim::Format::Type * input,
+            const typename T::Sim::Format::Type * const input,
             std::vector<LshDatatype> & output
         ) const {
             // In order to avoid allocating a new vector to hold the tensored data

--- a/include/puffinn/hash_source/tensor.hpp
+++ b/include/puffinn/hash_source/tensor.hpp
@@ -111,7 +111,7 @@ namespace puffinn {
 
         void hash_repetitions(
             const typename T::Sim::Format::Type * const input,
-            std::vector<LshDatatype> & output
+            std::vector<uint64_t> & output
         ) const {
             // In order to avoid allocating a new vector to hold the tensored data
             // every time we hash something, we make the output vector a little bit larger:

--- a/include/puffinn/prefixmap.hpp
+++ b/include/puffinn/prefixmap.hpp
@@ -248,7 +248,6 @@ namespace puffinn {
 
         // Construct a query object to search for the nearest neighbors of the given vector.
         PrefixMapQuery create_query(LshDatatype hash) const {
-        // PrefixMapQuery create_query(HashSourceState* hash_state) const {
             g_performance_metrics.start_timer(Computation::CreateQuery);
             auto prefix = hash >> (hash_length-PREFIX_INDEX_BITS);
             PrefixMapQuery res(

--- a/include/puffinn/sorthash.hpp
+++ b/include/puffinn/sorthash.hpp
@@ -1,0 +1,197 @@
+#pragma once
+
+#include "puffinn/typedefs.hpp"
+#include <algorithm>
+
+namespace puffinn {
+
+#define _0(x)	(x & 0xFF)
+#define _1(x)	(x >> 8 & 0xFF)
+#define _2(x)	(x >> 16 & 0xFF)
+
+// This macro is useful for debugging purposes
+#define print_bytes(arr) \
+    for (size_t i = 0; i < arr.size(); i++) { \
+        const uint32_t hi = arr[i]; \
+        printf("[%d]  %d  |  %d  |  %d\n", i, _0(hi), _1(hi), _2(hi)); \
+    } \
+    printf("\n\n");
+
+#define do_pass_simple1(arr_in, arr_out, bx, get_byte) \
+    for (size_t i = 0; i < n; i++) {           \
+        const uint32_t hi = arr_in[i];     \
+        const uint32_t pos = get_byte(hi);       \
+        arr_out[bx[pos]++] = hi;           \
+    }
+
+#define do_pass_unrolled1(arr_in, arr_out, bx, get_byte)       \
+    {                                                         \
+    size_t off = 0;                                           \
+    for (; off + 4 < n; off += 4) {                           \
+        const uint32_t hi0 = arr_in[off    ];                 \
+        const uint32_t hi1 = arr_in[off + 1];                 \
+        const uint32_t hi2 = arr_in[off + 2];                 \
+        const uint32_t hi3 = arr_in[off + 3];                 \
+                                                              \
+        const uint32_t pos0 = get_byte(hi0);                  \
+        const uint32_t pos1 = get_byte(hi1);                  \
+        const uint32_t pos2 = get_byte(hi2);                  \
+        const uint32_t pos3 = get_byte(hi3);                  \
+                                                              \
+        arr_out[bx[pos0]++] = hi0;                            \
+        arr_out[bx[pos1]++] = hi1;                            \
+        arr_out[bx[pos2]++] = hi2;                            \
+        arr_out[bx[pos3]++] = hi3;                            \
+    }                                                         \
+    for (; off < n; off++) {                                  \
+        const uint32_t hi = arr_in[off];                      \
+        const uint32_t pos = get_byte(hi);                    \
+        arr_out[bx[pos]++] = hi;                              \
+    }                                                         \
+    }              
+
+#define do_pass1 do_pass_unrolled1
+
+//! Sort the given vector of hash values, with n bytes of auxiliary space, using adix Sort
+//! with three passes over the data. Assumes that the hash values are stored in 
+//! the 24 least significant bits of each 32 bit integer.
+void sort_hashes_24(std::vector<uint32_t> & hashes, std::vector<uint32_t> & out) {
+    const size_t n = hashes.size();
+    const size_t n_bytes = 256;
+    out.clear();
+    out.resize(n, 0);
+
+    // Histograms on the stack
+    uint32_t b0[n_bytes], b1[n_bytes], b2[n_bytes];
+    for (size_t i = 0; i < n_bytes; i++) {
+        b0[i] = 0;
+        b1[i] = 0;
+        b2[i] = 0;
+    }
+
+    // One-pass histogram computation
+    for (size_t i = 0; i < n; i++) {
+        const uint32_t hi = hashes[i];
+        b0[_0(hi)]++;
+        b1[_1(hi)]++;
+        b2[_2(hi)]++;
+    }
+
+    // Cumulative sum of the histograms, which then keep track 
+    // of the write head position for each byte
+    {
+        uint32_t tsum = 0; // Re-set and reused for all three histograms
+        uint32_t
+            sum0 = 0,
+            sum1 = 0,
+            sum2 = 0;
+
+        for (size_t i = 0; i < n_bytes; i++) {
+            tsum = sum0 + b0[i];
+            b0[i] = sum0;
+            sum0 = tsum;
+
+            tsum = sum1 + b1[i];
+            b1[i] = sum1;
+            sum1 = tsum;
+
+            tsum = sum2 + b2[i];
+            b2[i] = sum2;
+            sum2 = tsum;
+        }
+    }
+
+    // First sorting pass
+    do_pass1(hashes, out, b0, _0);
+
+    // Second sorting pass
+    do_pass1(out, hashes, b1, _1);
+
+    // Third sorting pass
+    do_pass1(hashes, out, b2, _2);
+}
+
+#define do_pass_simple(arr_in, arr_out, idx_in, idx_out, bx, get_byte) \
+    for (size_t i = 0; i < n; i++) {           \
+        const uint32_t hi = arr_in[i];     \
+        const uint32_t pos = get_byte(hi);       \
+        const uint32_t t = bx[pos]++;   \
+        arr_out[t] = hi;           \
+        idx_out[t] = idx_in[i]; \
+    }
+
+#define do_pass do_pass_simple
+
+//! Sort the given vector of hash values, along with the corresponding vector of 
+//! identifiers, with n bytes of auxiliary space, using Radix Sort
+//! with three passes over the data. Assumes that the hash values are stored in 
+//! the 24 least significant bits of each 32 bit integer.
+//!
+//! In this sort routine, the indices provided in the `idx_in` argument are considered
+//! as forming a pair with the hashes in `hashes_in`, and will be sorted along with them
+//! as if we were sorting an array of std::pair using the hash as key.
+void sort_hashes_pairs_24(
+    std::vector<uint32_t> & hashes_in,
+    std::vector<uint32_t> & hashes_out,
+    std::vector<uint32_t> & idx_in,
+    std::vector<uint32_t> & idx_out
+) {
+    const size_t n = hashes_in.size();
+    const size_t n_bytes = 256;
+    hashes_out.clear();
+    hashes_out.resize(n, 0);
+    idx_out.clear();
+    idx_out.resize(n, 0);
+
+    // Histograms on the stack
+    uint32_t b0[n_bytes], b1[n_bytes], b2[n_bytes];
+    for (size_t i = 0; i < n_bytes; i++) {
+        b0[i] = 0;
+        b1[i] = 0;
+        b2[i] = 0;
+    }
+
+    // One-pass histogram computation
+    for (size_t i = 0; i < n; i++) {
+        const uint32_t hi = hashes_in[i];
+        b0[_0(hi)]++;
+        b1[_1(hi)]++;
+        b2[_2(hi)]++;
+    }
+
+    // Cumulative sum of the histograms, which then keep track 
+    // of the write head position for each byte
+    {
+        uint32_t tsum = 0; // Re-set and reused for all three histograms
+        uint32_t
+            sum0 = 0,
+            sum1 = 0,
+            sum2 = 0;
+
+        for (size_t i = 0; i < n_bytes; i++) {
+            tsum = sum0 + b0[i];
+            b0[i] = sum0;
+            sum0 = tsum;
+
+            tsum = sum1 + b1[i];
+            b1[i] = sum1;
+            sum1 = tsum;
+
+            tsum = sum2 + b2[i];
+            b2[i] = sum2;
+            sum2 = tsum;
+        }
+    }
+
+    // First sorting pass
+    do_pass(hashes_in, hashes_out, idx_in, idx_out, b0, _0);
+
+    // Second sorting pass
+    do_pass(hashes_out, hashes_in, idx_out, idx_in, b1, _1);
+
+    // Third sorting pass
+    do_pass(hashes_in, hashes_out, idx_in, idx_out, b2, _2);
+}
+
+
+} // namespace puffinn

--- a/test/include/filterer_test.hpp
+++ b/test/include/filterer_test.hpp
@@ -21,7 +21,8 @@ namespace filterer_test {
 
         std::vector<float> query({1, 0});
         auto stored = to_stored_type<UnitVectorFormat>(query, dataset.get_description());
-        auto sketches = filterer.reset(stored.get());
+        QuerySketches sketches;
+        filterer.sketch(stored.get(), sketches);
 
         // Anything initially passes
         for (size_t i=0; i < NUM_SKETCHES; i++) {

--- a/test/include/hash_source_test.hpp
+++ b/test/include/hash_source_test.hpp
@@ -17,12 +17,14 @@ namespace hash_source {
         auto stored1 = to_stored_type<typename T::Sim::Format>(vec1, dimensions);
         auto stored2 = to_stored_type<typename T::Sim::Format>(vec2, dimensions);
 
-        auto hasher = source->sample();
-        auto state = source->reset(stored1.get(), false);
-        auto hash1 = (*hasher)(state.get());
-        state = source->reset(stored2.get(), false);
-        auto hash2 = (*hasher)(state.get());
-        REQUIRE(hash1 != hash2);
+        REQUIRE(source);
+
+        /* auto hasher = source->sample(); */
+        /* auto state = source->reset(stored1.get(), false); */
+        /* auto hash1 = (*hasher)(state.get()); */
+        /* state = source->reset(stored2.get(), false); */
+        /* auto hash2 = (*hasher)(state.get()); */
+        /* REQUIRE(hash1 != hash2); */
     }
 
     template <typename T>
@@ -62,38 +64,41 @@ namespace hash_source {
         }
     }
 
-    TEST_CASE("HashPool reset") {
-        Dataset<UnitVectorFormat> dataset(100);
-        auto dimensions = dataset.get_description();
-        test_reset<SimHash>(
-            dimensions,
-            HashPoolArgs<SimHash>(50).build(dimensions, 0, 24));
-        test_reset<FHTCrossPolytopeHash>(
-            dimensions,
-            HashPoolArgs<FHTCrossPolytopeHash>(80).build(dimensions, 0, 20));
-    }
+    // FIXME: Remove
+    /* TEST_CASE("HashPool reset") { */
+    /*     Dataset<UnitVectorFormat> dataset(100); */
+    /*     auto dimensions = dataset.get_description(); */
+    /*     test_reset<SimHash>( */
+    /*         dimensions, */
+    /*         HashPoolArgs<SimHash>(50).build(dimensions, 0, 24)); */
+    /*     test_reset<FHTCrossPolytopeHash>( */
+    /*         dimensions, */
+    /*         HashPoolArgs<FHTCrossPolytopeHash>(80).build(dimensions, 0, 20)); */
+    /* } */
 
-    TEST_CASE("IndependentSource reset") {
-        Dataset<UnitVectorFormat> dataset(100);
-        auto dimensions = dataset.get_description();
-        test_reset<SimHash>(
-            dimensions,
-            IndependentHashArgs<SimHash>().build(dimensions, 2, 20));
-        test_reset<FHTCrossPolytopeHash>(
-            dimensions,
-            IndependentHashArgs<FHTCrossPolytopeHash>().build(dimensions, 2, 20));
-    }
-
-    TEST_CASE("TensoredHash reset") {
-        Dataset<UnitVectorFormat> dataset(100);
-        auto dimensions = dataset.get_description();
-        test_reset<SimHash>(
-            dimensions,
-            TensoredHashArgs<SimHash>().build(dimensions, 2, 20));
-        test_reset<FHTCrossPolytopeHash>(
-            dimensions,
-            TensoredHashArgs<FHTCrossPolytopeHash>().build(dimensions, 2, 20));
-    }
+    // FIXME: remove
+    /* TEST_CASE("IndependentSource reset") { */
+    /*     Dataset<UnitVectorFormat> dataset(100); */
+    /*     auto dimensions = dataset.get_description(); */
+    /*     test_reset<SimHash>( */
+    /*         dimensions, */
+    /*         IndependentHashArgs<SimHash>().build(dimensions, 2, 20)); */
+    /*     test_reset<FHTCrossPolytopeHash>( */
+    /*         dimensions, */
+    /*         IndependentHashArgs<FHTCrossPolytopeHash>().build(dimensions, 2, 20)); */
+    /* } */
+    
+    // FIXME: remove
+    /* TEST_CASE("TensoredHash reset") { */
+    /*     Dataset<UnitVectorFormat> dataset(100); */
+    /*     auto dimensions = dataset.get_description(); */
+    /*     test_reset<SimHash>( */
+    /*         dimensions, */
+    /*         TensoredHashArgs<SimHash>().build(dimensions, 2, 20)); */
+    /*     test_reset<FHTCrossPolytopeHash>( */
+    /*         dimensions, */
+    /*         TensoredHashArgs<FHTCrossPolytopeHash>().build(dimensions, 2, 20)); */
+    /* } */
 
     TEST_CASE("HashPool hashes") {
         const unsigned int HASH_LENGTH = 24;

--- a/test/include/hash_source_test.hpp
+++ b/test/include/hash_source_test.hpp
@@ -18,10 +18,6 @@ namespace hash_source {
         unsigned int hash_length
     ) {
         std::vector<int> bit_occurences(hash_length, 0);
-        std::vector<std::unique_ptr<Hash>> hash_functions;
-        for (unsigned int i=0; i < num_hashes; i++) {
-            hash_functions.push_back(source->sample());
-        }
 
         // Test with a couple of different vectors since the limited range of some hash functions
         // (such as FHTCrossPolytope) can lead to some bits unused.


### PR DESCRIPTION
This pull request backports the changes made to the entire hashing infrastructure that were made to support the implementation of the [closest pairs functionality](https://github.com/Cecca/puffinn).
In that setting, the time to build the index is very relevant.

## tl;dr

These changes aim at simplifying the hashing infrastructure, enabling better use of parallel resources.
The result, in terms of performance, is summarized in the following table, which report the time to build the index on `glove-100-angular` along with the time to answer the 10k queries built into the dataset.

|                git_commit                |   time_index_s   |   time_query_s   |
|------------------------------------------|------------------|------------------|
| ce749abcb553383afd4daadedf7ffadb51587682 | 150.665 | 48.142 |
| d7a166cca229722c1dac2e78cea7e726888816ed | 49.434 | 45.839 |

Times are measured on `preciousss` using the `scripts/minibench.py` script. The new code is 3 times faster at building the index.

## Previous situation

Previously in order to compute the hash values associated with a vector we used several classes.
Starting from a `HashSource` (for instance `IndependentHashSource`) we obtained an instance of `HashSourceState` by invoking `HashSource::reset` on the vector to hash. Then, to actually compute the hash value we had to first sample a hash function from the `HashSource` using `HashSource::sample`. The resulting `Hash` instance then implemented `operator()` that accepted the `HashSourceState`: when invoked it returned the actual hash value.
Multiple repetitions (which are the _raison d'être_ of the `HashSource` classes) can then be executed by sampling multiple `Hash` functions and invoking their `operator()` on the same `HashSourceState`.

All of these objects were then managed by means of smart pointers. To my surprise this didn't seem to have large impact on the performance. Most likely the compiler was able to optimize away most of the indirections.

The main issue with this architecture is that hashing is **stateful**, making parallel computation hard.

## Proposed changes

Very simply, this pull request replaces all of the above with a single method `HashSource::hash_repetitions`

https://github.com/Cecca/puffinn/blob/d7a166cca229722c1dac2e78cea7e726888816ed/include/puffinn/hash_source/hash_source.hpp#L24-L29

This function takes the vector (in the metric space sense) to hash and a vector (in the C++ sense) that will be populated with the hash values for _all_ repetitions supported by the HashSource.

This removes the need to manage state, simplifying the code and allowing for more parallelism.
Furthermore, now `prefixmap` no longer needs to know about the hash functions: it just manages the hash values computed elsewhere.

## Bonus

This pull request also includes, in the construction of the prefix maps, the use of radix sort in place of the standard library's sort. For our use case it is faster.

https://github.com/Cecca/puffinn/blob/d7a166cca229722c1dac2e78cea7e726888816ed/include/puffinn/prefixmap.hpp#L202-L207