### PR TITLE
make the random number generator explicit

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,8 +1,15 @@
+install-python:
+    pip uninstall puffinn
+    python setup.py install
+
+build-python:
+    python setup.py build
+
 test: build
     build/Test
 
 build:
-    cmake --build build
+    cmake --build build --config Debug
 
 clean:
     cd build && make clean

--- a/examples/closest-pairs.py
+++ b/examples/closest-pairs.py
@@ -31,7 +31,7 @@ for g in ground_truth:
 # Construct the search index.
 # Here we use angular distance aka cosine similarity
 # with the default hash functions and 500MB memory.
-index = Index('angular', dimensions, 500*MB)
+index = Index('angular', dimensions, 500*MB, 12345)
 print('Building index')
 for v in dataset:
     index.insert(v)

--- a/examples/glove.cpp
+++ b/examples/glove.cpp
@@ -3,6 +3,7 @@
 
 #include <cstdlib>
 #include <fstream>
+#include <random>
 #include <sstream>
 #include <iostream>
 #include <map>
@@ -54,7 +55,8 @@ int main(int argc, char* argv[]) {
     // and will use at most the specified amount of memory.
     puffinn::Index<puffinn::CosineSimilarity> index(
         dimensions,
-        space_usage
+        space_usage,
+        std::mt19937_64(1234)
     );
     // Insert each vector into the index.
     for (auto word : dataset.words) { index.insert(dataset.vectors[word]); }

--- a/examples/random-vectors.py
+++ b/examples/random-vectors.py
@@ -26,7 +26,7 @@ ground_truth = [
 # Construct the search index.
 # Here we use angular distance aka cosine similarity
 # with the default hash functions and 500MB memory.
-index = Index('angular', dimensions, 500*MB)
+index = Index('angular', dimensions, 500*MB, 12345)
 print('Building index')
 for v in dataset:
     index.insert(v)

--- a/include/puffinn/filterer.hpp
+++ b/include/puffinn/filterer.hpp
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <immintrin.h>
 #include <memory>
+#include <random>
 
 namespace puffinn {
     const size_t NUM_SKETCHES = 32;
@@ -40,12 +41,14 @@ namespace puffinn {
         std::unique_ptr<HashSourceArgs<T>> sketch_args;
 
     public:
-        Filterer(const HashSourceArgs<T>& args, DatasetDescription<typename T::Sim::Format> dataset)
+        Filterer(const HashSourceArgs<T>& args, DatasetDescription<typename T::Sim::Format> dataset, std::mt19937_64 &rng)
           : hash_source(
                 args.build(
                     dataset,
                     NUM_SKETCHES,
-                    NUM_FILTER_HASHBITS)),
+                    NUM_FILTER_HASHBITS,
+                    rng)
+            ),
             sketch_args(args.copy())
         {
         }

--- a/include/puffinn/format/real_vector.hpp
+++ b/include/puffinn/format/real_vector.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <random>
 #include <vector>
 
+#include "puffinn/typedefs.hpp"
 #include "puffinn/format/generic.hpp"
 
 namespace puffinn {
@@ -33,12 +35,11 @@ namespace puffinn {
 
         static void free(Type&) {}
 
-        static std::vector<float> generate_random(unsigned int dimensions) {
+        static std::vector<float> generate_random(unsigned int dimensions, std::mt19937_64 &rng) {
             std::normal_distribution<float> normal_distribution(0.0, 1.0);
-            auto& generator = get_default_random_generator();
             std::vector<float> values;
             for (unsigned int i=0; i<dimensions; i++) {
-                values.push_back(normal_distribution(generator));
+                values.push_back(normal_distribution(rng));
             }
             return values;
         }

--- a/include/puffinn/format/set.hpp
+++ b/include/puffinn/format/set.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <random>
 #include <vector>
 #include <istream>
 #include <ostream>
 
+#include "puffinn/typedefs.hpp"
 #include "puffinn/format/generic.hpp"
 
 namespace puffinn {
@@ -51,12 +53,11 @@ namespace puffinn {
             vec.~vector();
         }
 
-        static std::vector<uint32_t> generate_random(unsigned int dimensions) {
+        static std::vector<uint32_t> generate_random(unsigned int dimensions, std::mt19937_64 &rng) {
             // Probability of each element to be included in the set.
             const float INCLUSION_PROB = 0.3;
 
             std::uniform_real_distribution<float> dist(0.0, 1.0);
-            auto& rng = get_default_random_generator();
 
             std::vector<uint32_t> res;
             for (uint32_t i=0; i < dimensions; i++) {

--- a/include/puffinn/format/unit_vector.hpp
+++ b/include/puffinn/format/unit_vector.hpp
@@ -90,9 +90,8 @@ namespace puffinn {
 
         static void free(Type&) {}
 
-        static std::vector<float> generate_random(unsigned int dimensions) {
+        static std::vector<float> generate_random(unsigned int dimensions, std::mt19937_64 &generator) {
             std::normal_distribution<float> normal_distribution(0.0, 1.0);
-            auto& generator = get_default_random_generator();
 
             std::vector<float> values;
             for (unsigned int i=0; i<dimensions; i++) {

--- a/include/puffinn/hash/minhash.hpp
+++ b/include/puffinn/hash/minhash.hpp
@@ -2,6 +2,7 @@
 
 #include "puffinn/format/set.hpp"
 #include "puffinn/similarity_measure/jaccard.hpp"
+#include "puffinn/typedefs.hpp"
 
 #include <istream>
 #include <ostream>
@@ -198,10 +199,7 @@ namespace puffinn {
             out.write(reinterpret_cast<const char*>(&set_size), sizeof(unsigned int));
         }
 
-        Function sample() {
-            std::mt19937_64 rng;
-            rng.seed(get_default_random_generator()());
-
+        Function sample(std::mt19937_64 & rng) {
             BitPermutation perm(rng, set_size, args.randomized_bits);
             return Function(TabulationHash(rng), perm);
         }
@@ -268,8 +266,8 @@ namespace puffinn {
             minhash.serialize(out);
         }
 
-        Function sample() {
-            return Function(minhash.sample());
+        Function sample(std::mt19937_64 & rng) {
+            return Function(minhash.sample(rng));
         }
 
         unsigned int bits_per_function() const {

--- a/include/puffinn/hash/simhash.hpp
+++ b/include/puffinn/hash/simhash.hpp
@@ -7,6 +7,7 @@
 
 #include <istream>
 #include <ostream>
+#include <random>
 
 namespace puffinn {
     class SimHashFunction {
@@ -14,11 +15,11 @@ namespace puffinn {
         unsigned int dimensions;
 
     public:
-        SimHashFunction(DatasetDescription<UnitVectorFormat> dataset)
+        SimHashFunction(DatasetDescription<UnitVectorFormat> dataset, std::mt19937_64 &rng)
           : hash_vec(allocate_storage<UnitVectorFormat>(1, dataset.storage_len)),
             dimensions(dataset.storage_len)
         {
-            auto vec = UnitVectorFormat::generate_random(dataset.args);
+            auto vec = UnitVectorFormat::generate_random(dataset.args, rng);
             UnitVectorFormat::store(vec, hash_vec.get(), dataset);
         }
 
@@ -85,8 +86,8 @@ namespace puffinn {
             dataset.serialize(out);
         }
 
-        SimHashFunction sample() {
-            return SimHashFunction(dataset);
+        SimHashFunction sample(std::mt19937_64 &rng) {
+            return SimHashFunction(dataset, rng);
         }
 
         unsigned int bits_per_function() {

--- a/include/puffinn/hash_source/hash_source.hpp
+++ b/include/puffinn/hash_source/hash_source.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "puffinn/format/generic.hpp"
+#include <cstdint>
 #include <ostream>
+#include <random>
 
 namespace puffinn {
     enum class HashSourceType {
@@ -69,7 +72,8 @@ namespace puffinn {
         virtual std::unique_ptr<HashSource<T>> build(
             DatasetDescription<typename T::Sim::Format> desc,
             unsigned int num_tables,
-            unsigned int num_bits
+            unsigned int num_bits,
+            std::mt19937_64 &rng
         ) const = 0;
 
         virtual std::unique_ptr<HashSourceArgs<T>> copy() const = 0;

--- a/include/puffinn/hash_source/independent.hpp
+++ b/include/puffinn/hash_source/independent.hpp
@@ -2,6 +2,7 @@
 
 #include "puffinn/dataset.hpp"
 #include "puffinn/hash_source/hash_source.hpp"
+#include <random>
 
 namespace puffinn {
     // A source of completely independent hash functions.
@@ -22,7 +23,9 @@ namespace puffinn {
             // Number of hashers to create.
             unsigned int num_hashers,
             // Number of bits per hasher.
-            unsigned int num_bits
+            unsigned int num_bits,
+            // Random number generator for sampling
+            std::mt19937_64 &rng
         ) 
           : hash_family(desc, args), num_hashers(num_hashers)
         {
@@ -33,7 +36,7 @@ namespace puffinn {
             bits_to_cut = bits_per_function*functions_per_hasher-num_bits;
             hash_functions.reserve(num_functions);
             for (unsigned int i=0; i < num_functions; i++) {
-                hash_functions.push_back(hash_family.sample());
+                hash_functions.push_back(hash_family.sample(rng));
             }
         }
 
@@ -141,13 +144,15 @@ namespace puffinn {
         std::unique_ptr<HashSource<T>> build(
             DatasetDescription<typename T::Sim::Format> desc,
             unsigned int num_tables,
-            unsigned int num_bits
+            unsigned int num_bits,
+            std::mt19937_64 &rng
         ) const {
             return std::make_unique<IndependentHashSource<T>> (
                 desc,
                 args,
                 num_tables,
-                num_bits
+                num_bits,
+                rng
             );
         }
 

--- a/include/puffinn/hash_source/tensor.hpp
+++ b/include/puffinn/hash_source/tensor.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "puffinn/hash_source/independent.hpp"
+#include <random>
 
 namespace puffinn {
     uint64_t intersperse_zero(int64_t val) {
@@ -49,13 +50,16 @@ namespace puffinn {
             // Number of hashers to create.
             unsigned int num_hashers,
             // Number of bits per hasher.
-            unsigned int num_bits
+            unsigned int num_bits,
+            std::mt19937_64 &rng
         ) 
           : independent_hash_source(
                 dimensions,
                 args,
                 2*std::ceil(std::sqrt(static_cast<float>(num_hashers))),
-                (num_bits+1)/2),
+                (num_bits+1)/2,
+                rng
+            ),
             num_hashers(num_hashers),
             num_bits(num_bits)
         {
@@ -191,13 +195,15 @@ namespace puffinn {
         std::unique_ptr<HashSource<T>> build(
             DatasetDescription<typename T::Sim::Format> desc,
             unsigned int num_tables,
-            unsigned int num_bits
+            unsigned int num_bits,
+            std::mt19937_64 &rng
         ) const {
             return std::make_unique<TensoredHashSource<T>> (
                 desc,
                 args,
                 num_tables,
-                num_bits
+                num_bits,
+                rng
             );
         }
 

--- a/include/puffinn/typedefs.hpp
+++ b/include/puffinn/typedefs.hpp
@@ -14,11 +14,10 @@ namespace puffinn {
     // The hash_pool concatenates hashes into a type twice as large to avoid overflow errors.
     using LshDatatype = uint32_t;
 
-    std::default_random_engine generator(std::chrono::system_clock::now().time_since_epoch().count());
-
-    // Retrieve the default random engine, seeded once by the system clock.
-    std::default_random_engine& get_default_random_generator() {
-        return generator;
+    static std::mt19937_64 get_random_generator(uint64_t seed) {
+        std::mt19937_64 rng;
+        rng.seed(seed);
+        return rng;
     }
 
     #if defined(__GNUC__)

--- a/scripts/minibench.py
+++ b/scripts/minibench.py
@@ -30,7 +30,7 @@ def run(data_path):
 
     print("  building index")
     t_start = time.time()
-    index = puffinn.Index("angular", dimensions, 4 * 1024 * MB)
+    index = puffinn.Index("angular", dimensions, 4 * 1024 * MB, 12345)
     for v in train:
         v = list(v)
         index.insert(v)

--- a/test/include/dataset_test.hpp
+++ b/test/include/dataset_test.hpp
@@ -6,6 +6,7 @@
 #include "puffinn/format/unit_vector.hpp"
 
 #include <cstring>
+#include <random>
 
 namespace dataset {
     using namespace puffinn;
@@ -31,6 +32,7 @@ namespace dataset {
     }
 
     TEST_CASE("Dynamic resizing") {
+        std::mt19937_64 rng;
         const unsigned int DIMENSIONS = 120;
         const unsigned int SIZE = 10000;
 
@@ -40,7 +42,7 @@ namespace dataset {
         vec[1] = 1.0;
         dataset.insert(vec);
         for (unsigned int i=0; i < SIZE; i++) {
-            dataset.insert(UnitVectorFormat::generate_random(DIMENSIONS));
+            dataset.insert(UnitVectorFormat::generate_random(DIMENSIONS, rng));
         }
 
         REQUIRE(dataset.get_size() == SIZE+1);

--- a/test/include/filterer_test.hpp
+++ b/test/include/filterer_test.hpp
@@ -5,17 +5,19 @@
 #include "puffinn/format/unit_vector.hpp"
 #include "puffinn/hash_source/independent.hpp"
 #include "puffinn/hash/simhash.hpp"
+#include <random>
 
 using namespace puffinn;
 
 namespace filterer_test {
     TEST_CASE("filtering equal/opposite vector") {
+        std::mt19937_64 rng;
         Dataset<UnitVectorFormat> dataset(2);
         dataset.insert(std::vector<float>({1, 0}));
         dataset.insert(std::vector<float>({-1, 0}));
 
         IndependentHashArgs<SimHash> hash_args;
-        Filterer<SimHash> filterer(hash_args, dataset.get_description());
+        Filterer<SimHash> filterer(hash_args, dataset.get_description(), rng);
 
         filterer.add_sketches(dataset, 0);
 
@@ -42,16 +44,17 @@ namespace filterer_test {
     }
 
     TEST_CASE("All filtering bits used") {
+        std::mt19937_64 rng;
         const int NUM_VECTORS = 20;
         const unsigned int DIMENSIONS = 100;
 
         Dataset<UnitVectorFormat> dataset(DIMENSIONS);
         for (int i=0; i < NUM_VECTORS; i++) {
-            dataset.insert(UnitVectorFormat::generate_random(DIMENSIONS));
+            dataset.insert(UnitVectorFormat::generate_random(DIMENSIONS, rng));
         }
 
         IndependentHashArgs<SimHash> hash_args;
-        Filterer<SimHash> filterer(hash_args, dataset.get_description());
+        Filterer<SimHash> filterer(hash_args, dataset.get_description(), rng);
         filterer.add_sketches(dataset, 0);
 
         int bit_counts[NUM_FILTER_HASHBITS];

--- a/test/include/hash_source_test.hpp
+++ b/test/include/hash_source_test.hpp
@@ -6,6 +6,7 @@
 #include "puffinn/hash_source/tensor.hpp"
 #include "puffinn/hash/simhash.hpp"
 #include "puffinn/hash/crosspolytope.hpp"
+#include <random>
 
 using namespace puffinn;
 
@@ -18,11 +19,12 @@ namespace hash_source {
         unsigned int hash_length
     ) {
         std::vector<int> bit_occurences(hash_length, 0);
+        std::mt19937_64 rng;
 
         // Test with a couple of different vectors since the limited range of some hash functions
         // (such as FHTCrossPolytope) can lead to some bits unused.
         for (int vec_idx = 0; vec_idx < 2; vec_idx++) {
-            auto vec = UnitVectorFormat::generate_random(dimensions.args);
+            auto vec = UnitVectorFormat::generate_random(dimensions.args, rng);
             auto stored = to_stored_type<typename T::Sim::Format>(vec, dimensions);
             std::vector<uint64_t> hashes;
             source->hash_repetitions(stored.get(), hashes);
@@ -45,30 +47,32 @@ namespace hash_source {
     }
 
     TEST_CASE("HashPool hashes") {
+        std::mt19937_64 rng;
         const unsigned int HASH_LENGTH = 24;
         unsigned int samples = 100;
         Dataset<UnitVectorFormat> dataset(100);
         auto dimensions = dataset.get_description();
         test_hashes<SimHash>(
             dimensions,
-            HashPoolArgs<SimHash>(60).build(dimensions, samples, HASH_LENGTH),
+            HashPoolArgs<SimHash>(60).build(dimensions, samples, HASH_LENGTH, rng),
             samples,
             HASH_LENGTH);
         test_hashes<FHTCrossPolytopeHash>(
             dimensions,
-            HashPoolArgs<FHTCrossPolytopeHash>(60).build(dimensions, samples, HASH_LENGTH),
+            HashPoolArgs<FHTCrossPolytopeHash>(60).build(dimensions, samples, HASH_LENGTH, rng),
             samples,
             HASH_LENGTH);
     }
 
     TEST_CASE("HashPool sketches") {
+        std::mt19937_64 rng;
         const unsigned int HASH_LENGTH = 64;
         unsigned int samples = 100;
         Dataset<UnitVectorFormat> dataset(100);
         auto dimensions = dataset.get_description();
         test_hashes<SimHash>(
             dimensions,
-            HashPoolArgs<SimHash>(60).build(dimensions, samples, HASH_LENGTH),
+            HashPoolArgs<SimHash>(60).build(dimensions, samples, HASH_LENGTH, rng),
             samples,
             HASH_LENGTH);
     }
@@ -77,17 +81,18 @@ namespace hash_source {
     TEST_CASE("Independent hashes") {
         const unsigned int HASH_LENGTH = 24;
         const unsigned int NUM_HASHES = 100;
+        std::mt19937_64 rng;
 
         Dataset<UnitVectorFormat> dataset(100);
         auto dimensions = dataset.get_description();
         test_hashes<SimHash>(
             dimensions,
-            IndependentHashArgs<SimHash>().build(dimensions, NUM_HASHES, HASH_LENGTH),
+            IndependentHashArgs<SimHash>().build(dimensions, NUM_HASHES, HASH_LENGTH, rng),
             NUM_HASHES,
             HASH_LENGTH);
         test_hashes<FHTCrossPolytopeHash>(
             dimensions,
-            IndependentHashArgs<FHTCrossPolytopeHash>().build(dimensions, NUM_HASHES, HASH_LENGTH),
+            IndependentHashArgs<FHTCrossPolytopeHash>().build(dimensions, NUM_HASHES, HASH_LENGTH, rng),
             NUM_HASHES,
             HASH_LENGTH);
     }
@@ -96,17 +101,18 @@ namespace hash_source {
     TEST_CASE("Tensored hashes") {
         const unsigned int HASH_LENGTH = 24;
         const unsigned int NUM_HASHES = 100;
+        std::mt19937_64 rng;
 
         Dataset<UnitVectorFormat> dataset(100);
         auto dimensions = dataset.get_description();
         test_hashes<SimHash>(
             dimensions,
-            TensoredHashArgs<SimHash>().build(dimensions, NUM_HASHES, HASH_LENGTH),
+            TensoredHashArgs<SimHash>().build(dimensions, NUM_HASHES, HASH_LENGTH, rng),
             NUM_HASHES,
             HASH_LENGTH);
         test_hashes<FHTCrossPolytopeHash>(
             dimensions,
-            TensoredHashArgs<FHTCrossPolytopeHash>().build(dimensions, NUM_HASHES, HASH_LENGTH),
+            TensoredHashArgs<FHTCrossPolytopeHash>().build(dimensions, NUM_HASHES, HASH_LENGTH, rng),
             NUM_HASHES,
             HASH_LENGTH);
     }

--- a/test/include/math_test.hpp
+++ b/test/include/math_test.hpp
@@ -6,6 +6,7 @@
 #include "puffinn/math.hpp"
 #include "puffinn/format/unit_vector.hpp"
 #include "puffinn/format/real_vector.hpp"
+#include <random>
 
 namespace math {
     using namespace puffinn;
@@ -14,10 +15,11 @@ namespace math {
         unsigned reps = 100;
         unsigned dims = 100;
         Dataset<UnitVectorFormat> dataset(dims);
+        std::mt19937_64 rng;
 
         for (unsigned i=0; i < reps; i++) {
-            auto a = UnitVectorFormat::generate_random(dims);
-            auto b = UnitVectorFormat::generate_random(dims);
+            auto a = UnitVectorFormat::generate_random(dims, rng);
+            auto b = UnitVectorFormat::generate_random(dims, rng);
             auto sa = to_stored_type<UnitVectorFormat>(a, dataset.get_description());
             auto sb = to_stored_type<UnitVectorFormat>(b, dataset.get_description());
 
@@ -33,10 +35,11 @@ namespace math {
         unsigned reps = 100;
         unsigned dims = 100;
         Dataset<RealVectorFormat> dataset(dims);
+        std::mt19937_64 rng;
 
         for (unsigned i=0; i < reps; i++) {
-            auto a = RealVectorFormat::generate_random(dims);
-            auto b = RealVectorFormat::generate_random(dims);
+            auto a = RealVectorFormat::generate_random(dims, rng);
+            auto b = RealVectorFormat::generate_random(dims, rng);
             auto sa = to_stored_type<RealVectorFormat>(a, dataset.get_description());
             auto sb = to_stored_type<RealVectorFormat>(b, dataset.get_description());
 


### PR DESCRIPTION
This pull request enables deterministic runs and reproducible tests.
The main change is the removal of the global `get_default_random_generator` function from `typedefs.hpp`.
Now all the functions that make random choices (e.g. sampling lsh functions) take an explicit `std::mt19937_64` random number generator parameter.

This allows seeding the entire process allowing deterministic executions.